### PR TITLE
Fix for convergence test when maximum likelihood is positive

### DIFF
--- a/R/wordfish.R
+++ b/R/wordfish.R
@@ -258,7 +258,7 @@ wordfish <- function(wfm,
     
     ll <- LL(params, tY)
     if (conv.check=='ll'){
-      diff <- (ll - old.ll)/ll
+      diff <- (ll - old.ll)/abs(old.ll)
       if (verbose) {
         cat("LL:", ll, "\n")
         flush.console()


### PR DESCRIPTION
I came across a problem with the wordfish routine calculating that convergence was complete when this wasn't the case. Here's a simple fix.